### PR TITLE
add support for android bundle artifacts aab

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -112,6 +112,9 @@ workflows:
             elif [[ ! -e "$BITRISE_APK_PATH" ]]; then
                 echo "Does not exist: apk file's path"
                 exit 1
+            elif [[ ! -e "$BITRISE_AAB_PATH" ]]; then
+                echo "Does not exist: aab file's path"
+                exit 1
             fi
     - change-workdir:
         title: Change back to original working directory

--- a/main.go
+++ b/main.go
@@ -149,11 +149,8 @@ func findArtifact(rootDir, ext string, buildStart time.Time) ([]string, error) {
 func checkBuildProducts(apks []string, aabs []string, apps []string, ipas []string, platforms []string, target string) error {
 	// if android in platforms
 	if sliceutil.IsStringInSlice("android", platforms) {
-		if len(apks) == 0 && target == "emulator" {
-			return errors.New("No apk generated")
-		}
-		if len(aabs) == 0 && target == "device" {
-			return errors.New("no aabs generated")
+		if len(apks) == 0 || len(aabs) == 0 {
+			return errors.New("No apk or aab generated")
 		}
 	}
 	// if ios in platforms

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ const (
 	dsymZipPathEnvKey = "BITRISE_DSYM_PATH"
 
 	apkPathEnvKey = "BITRISE_APK_PATH"
+	aabPathEnvKey = "BITRISE_AAB_PATH"
 )
 
 type config struct {
@@ -145,10 +146,15 @@ func findArtifact(rootDir, ext string, buildStart time.Time) ([]string, error) {
 	return matches, nil
 }
 
-func checkBuildProducts(apks []string, apps []string, ipas []string, platforms []string, target string) error {
+func checkBuildProducts(apks []string, aabs []string, apps []string, ipas []string, platforms []string, target string) error {
 	// if android in platforms
-	if len(apks) == 0 && sliceutil.IsStringInSlice("android", platforms) {
-		return errors.New("No apk generated")
+	if sliceutil.IsStringInSlice("android", platforms) {
+		if len(apks) == 0 && target == "emulator" {
+			return errors.New("No apk generated")
+		}
+		if len(aabs) == 0 && target == "device" {
+			return errors.New("no aabs generated")
+		}
 	}
 	// if ios in platforms
 	if sliceutil.IsStringInSlice("ios", platforms) {
@@ -361,11 +367,12 @@ func main() {
 		}
 	}
 
-	var apks []string
+	var apks, aabs []string
 	androidOutputDirExist := false
 	// examples for apk paths:
 	// PROJECT_ROOT/platforms/android/app/build/outputs/apk/debug/app-debug.apk
 	// PROJECT_ROOT/platforms/android/build/outputs/apk/debug/app-debug.apk
+	// PROJECT_ROOT/platforms/android/build/outputs/bundle/release/app.aab
 	androidOutputDir := filepath.Join(workDir, "platforms", "android")
 	if exist, err := pathutil.IsDirExists(androidOutputDir); err != nil {
 		fail("Failed to check if dir (%s) exist, error: %s", iosOutputDir, err)
@@ -387,6 +394,19 @@ func main() {
 				log.Donef("The apk path is now available in the Environment Variable: %s (value: %s)", apkPathEnvKey, exportedPth)
 			}
 		}
+
+		aabs, err = findArtifact(androidOutputDir, "aab", compileStart)
+		if err != nil {
+			fail("Failed to find aab in dir (%s), error: %s", androidOutputDir, err)
+		}
+
+		if len(aabs) > 0 {
+			if exportedPth, err := moveAndExportOutputs(aabs, configs.DeployDir, aabPathEnvKey, false); err != nil {
+				fail("Failed to export aabs, error: %s", err)
+			} else {
+				log.Donef("The apk path is now available in the Environment Variable: %s (value: %s)", aabPathEnvKey, exportedPth)
+			}
+		}
 	}
 
 	if !iosOutputDirExist && !androidOutputDirExist {
@@ -394,7 +414,7 @@ func main() {
 		fail("No output generated")
 	}
 
-	if err := checkBuildProducts(apks, apps, ipas, platforms, configs.Target); err != nil {
+	if err := checkBuildProducts(apks, aabs, apps, ipas, platforms, configs.Target); err != nil {
 		fail("Build outputs missing: %s", err)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import "testing"
 func Test_checkBuildProducts(t *testing.T) {
 	type args struct {
 		apks      []string
+		aabs      []string
 		apps      []string
 		ipas      []string
 		platforms []string
@@ -21,6 +22,7 @@ func Test_checkBuildProducts(t *testing.T) {
 				[]string{},
 				[]string{},
 				[]string{},
+				[]string{},
 				[]string{"ios", "android"},
 				"emulator",
 			},
@@ -29,6 +31,7 @@ func Test_checkBuildProducts(t *testing.T) {
 		{
 			"No android FAIL, ios generated",
 			args{
+				[]string{},
 				[]string{},
 				[]string{"/path.app"},
 				[]string{},
@@ -43,6 +46,19 @@ func Test_checkBuildProducts(t *testing.T) {
 				[]string{"/path.apk"},
 				[]string{},
 				[]string{},
+				[]string{},
+				[]string{"ios", "android"},
+				"emulator",
+			},
+			true,
+		},
+		{
+			"No ios FAIL, android generated",
+			args{
+				[]string{},
+				[]string{"/path.aab"},
+				[]string{},
+				[]string{},
 				[]string{"ios", "android"},
 				"emulator",
 			},
@@ -51,6 +67,7 @@ func Test_checkBuildProducts(t *testing.T) {
 		{
 			"ios emulator target OK",
 			args{
+				[]string{},
 				[]string{},
 				[]string{"/path.app"},
 				[]string{},
@@ -64,6 +81,7 @@ func Test_checkBuildProducts(t *testing.T) {
 			args{
 				[]string{},
 				[]string{},
+				[]string{},
 				[]string{"/path.apk"},
 				[]string{"ios"},
 				"emulator",
@@ -73,6 +91,7 @@ func Test_checkBuildProducts(t *testing.T) {
 		{
 			"ios device target, app generated FAIL",
 			args{
+				[]string{},
 				[]string{},
 				[]string{"/app_path.app"},
 				[]string{},
@@ -86,6 +105,19 @@ func Test_checkBuildProducts(t *testing.T) {
 			args{
 				[]string{"/path.apk"},
 				[]string{},
+				[]string{},
+				[]string{"/path.ipa"},
+				[]string{"ios, android"},
+				"device",
+			},
+			false,
+		},
+		{
+			"ios, android OK",
+			args{
+				[]string{},
+				[]string{"/path.aab"},
+				[]string{},
 				[]string{"/path.ipa"},
 				[]string{"ios, android"},
 				"device",
@@ -95,7 +127,7 @@ func Test_checkBuildProducts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := checkBuildProducts(tt.args.apks, tt.args.apps, tt.args.ipas, tt.args.platforms, tt.args.target); (err != nil) != tt.wantErr {
+			if err := checkBuildProducts(tt.args.apks, tt.args.aabs, tt.args.apps, tt.args.ipas, tt.args.platforms, tt.args.target); (err != nil) != tt.wantErr {
 				t.Errorf("checkBuildProducts() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/main_test.go
+++ b/main_test.go
@@ -41,7 +41,7 @@ func Test_checkBuildProducts(t *testing.T) {
 			true,
 		},
 		{
-			"No ios FAIL, android generated",
+			"No ios FAIL, android apk generated",
 			args{
 				[]string{"/path.apk"},
 				[]string{},
@@ -53,14 +53,14 @@ func Test_checkBuildProducts(t *testing.T) {
 			true,
 		},
 		{
-			"No ios FAIL, android generated",
+			"No ios FAIL, android aab generated",
 			args{
 				[]string{},
 				[]string{"/path.aab"},
 				[]string{},
 				[]string{},
 				[]string{"ios", "android"},
-				"emulator",
+				"device",
 			},
 			true,
 		},

--- a/step.yml
+++ b/step.yml
@@ -136,3 +136,6 @@ outputs:
   - BITRISE_APK_PATH: ""
     opts:
       title: The created android .apk file's path
+  - BITRISE_AAB_PATH: ""
+    opts:
+      title: The created android .aab file's path


### PR DESCRIPTION
When setting up cordova to build a bundle artifact, the cordova-archive steps returns in a FAIL, because it can't find a `.apk` file.

A bundled artifact for android is a `.aab` file, which is supported in the deploy to bitrise.io and deploy to google play steps