### PR TITLE
Add APK/AAB config input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bitrise*
 .gows*
 _tmp/
+.idea/

--- a/cordova/cordova_test.go
+++ b/cordova/cordova_test.go
@@ -1,0 +1,63 @@
+package cordova
+
+import (
+	"testing"
+)
+
+func Test_platformCustomOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		model   Model
+		wantCmd string
+	}{
+		{
+			"Project with generic option and AAB output",
+			*New().SetCustomOptions("--release").SetPlatforms("android").SetAndroidAppType("aab"),
+			`cordova "compile" "android" "--release" "--" "--packageType=bundle"`,
+		},
+		{
+			"Project with generic option and APK output",
+			*New().SetCustomOptions("--release").SetPlatforms("android").SetAndroidAppType("apk"),
+			`cordova "compile" "android" "--release" "--" "--packageType=apk"`,
+		},
+		{
+			"Project with no generic option and APK output",
+			*New().SetPlatforms("android").SetAndroidAppType("apk"),
+			`cordova "compile" "android" "--" "--packageType=apk"`,
+		},
+		{
+			"Project with no generic option and AAB output",
+			*New().SetPlatforms("android").SetAndroidAppType("aab"),
+			`cordova "compile" "android" "--" "--packageType=bundle"`,
+		},
+		{
+			"Project with platform-specific and generic options and AAB output",
+			*New().SetCustomOptions("--release", "--", "--keystore=android.keystore").SetPlatforms("android").SetAndroidAppType("aab"),
+			`cordova "compile" "android" "--release" "--" "--packageType=bundle" "--keystore=android.keystore"`,
+		},
+		{
+			"Project with platform-specific and generic options and APK output",
+			*New().SetCustomOptions("--release", "--", "--keystore=android.keystore").SetPlatforms("android").SetAndroidAppType("apk"),
+			`cordova "compile" "android" "--release" "--" "--packageType=apk" "--keystore=android.keystore"`,
+		},
+		{
+			"Project with only packageType option and APK output",
+			*New().SetCustomOptions("--", `--packageType="bundle"`).SetPlatforms("android").SetAndroidAppType("apk"),
+			`cordova "compile" "android" "--" "--packageType=apk" "--packageType=\"bundle\""`,
+		},
+		{
+			"Project with only packageType option and AAB output",
+			*New().SetCustomOptions("--", `--packageType="bundle"`).SetPlatforms("android").SetAndroidAppType("bundle"),
+			`cordova "compile" "android" "--" "--packageType=bundle" "--packageType=\"bundle\""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.model.CompileCommand().PrintableCommandArgs()
+			if tt.wantCmd != cmd {
+				t.Errorf("Cordova command doesn't match wanted value.\nWant: %v\nGot: %s", tt.wantCmd, cmd)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/kballard/go-shellquote"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,7 +20,6 @@ import (
 	"github.com/bitrise-io/go-utils/sliceutil"
 	"github.com/bitrise-io/go-utils/ziputil"
 	"github.com/bitrise-steplib/steps-cordova-archive/cordova"
-	"github.com/kballard/go-shellquote"
 )
 
 const (
@@ -46,6 +46,7 @@ type config struct {
 	Options        string `env:"options"`
 	DeployDir      string `env:"BITRISE_DEPLOY_DIR"`
 	UseCache       bool   `env:"cache_local_deps,opt[true,false]"`
+	AndroidAppType string `env:"android_app_type,opt[apk,aab]"`
 }
 
 func installDependency(packageManager jsdependency.Tool, name string, version string) error {
@@ -245,6 +246,7 @@ func main() {
 		builder.SetPlatforms(platforms...)
 	}
 
+	builder.SetAndroidAppType(configs.AndroidAppType)
 	builder.SetConfiguration(configs.Configuration)
 	builder.SetTarget(configs.Target)
 

--- a/step.yml
+++ b/step.yml
@@ -104,7 +104,7 @@ inputs:
       - "true"
       - "false"
       is_required: true
-  - cordova_version: 
+  - cordova_version:
     opts:
       title: "Cordova version"
       description: |-
@@ -125,8 +125,6 @@ inputs:
       description: |-
         Use this input to specify custom options, to append to the end of the cordova-cli build command.
 
-        Add `-- --packageType="bundle"` to build an Android bundle (aab). (https://github.com/apache/cordova-android/pull/764)
-
         The new Xcode build system is now supported in cordova-ios@5.0.0 (https://github.com/apache/cordova-ios/issues/407).
         To use the legacy build system add `--buildFlag="-UseModernBuildSystem=0"` to the options string.
 
@@ -146,6 +144,17 @@ inputs:
       value_options:
       - "true"
       - "false"
+  - android_app_type: apk
+    opts:
+      category: Android
+      title: Android app type
+      summary: Distribution type when building the Android app
+      description: Distribution type when building the Android app
+      is_required: true
+      value_options:
+      - apk
+      - aab
+
 outputs:
   - BITRISE_IPA_PATH:
     opts:


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Google is making `*.aab` bundles a mandatory format to publish updates in the play store: 
https://android-developers.googleblog.com/2021/06/the-future-of-android-app-bundles-is.html

This change introduces `*.aab` support to the step.

https://bitrise.atlassian.net/browse/STEP-1310

### Changes

- New input: `android_app_type` with `apk` (default) and `aab` values.
- Custom CLI options still have higher priority than this new option
- Command construction respects custom CLI options with both generic and platform-specific options in the input. Order of CLI options:
1. Generic options from custom input (if any)
2. Separator (`--`)
3. `packageType` option
4. Platform options from custom input (if any)

### Investigation details

[Cordova CLI reference](https://cordova.apache.org/docs/en/10.x/reference/cordova-cli/)
[Cordova AAB feature PR](https://github.com/apache/cordova-android/pull/764)


### Decisions

<!-- Please list decisions that were made for this change. -->
