### PR TITLE
Added support for the new iOS naming convention in Cordova 7

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,4 +1,4 @@
-format_version: 6
+format_version: "12"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
@@ -14,10 +14,10 @@ workflows:
     before_run:
     - audit-this-step
     steps:
-    - go-list:
-    - golint:
-    - errcheck:
-    - go-test:
+    - go-list: {}
+    - golint: {}
+    - errcheck: {}
+    - go-test: {}
     after_run:
     - test-with-npm
     - test-with-yarn
@@ -61,7 +61,7 @@ workflows:
             rm -rf ./_tmp
     - change-workdir:
         title: Switch working dir to ./_tmp dir
-        run_if: true
+        run_if: "true"
         inputs:
         - path: ./_tmp
         - is_create_path: true
@@ -93,8 +93,7 @@ workflows:
     - cordova-prepare:
         title: Cordova prepare
         run_if: '{{enveq "RUN_PREPARE_STEP" "true"}}'
-        inputs:
-        # - cordova_version: latest
+        inputs: []
     - path::./:
         title: Cordova archive
         inputs:

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -173,15 +174,22 @@ func fail(format string, v ...interface{}) {
 }
 
 func findIosTargetPathComponent(target string, configuration string, cordovaVersion string) string {
-	if cordovaVersion != "" && cordovaVersion[0:1] >= "7" {
-		targetPlatform := "iphonesimulator"
-		if (target == "device") {
-			targetPlatform = "iphoneos"
-		}
-		return fmt.Sprintf("%s-%s", strings.Title(configuration), targetPlatform)
-	} else {
-		return target // "emulator" or "device"
+	if cordovaVersion == "" {
+		return target
 	}
+
+	majorVersion, err := strconv.Atoi(cordovaVersion[0:1])
+	if err != nil || majorVersion < 7 {
+		// Pre-Cordova-7 behavior: path segment is just "device" or "emulator"
+		return target
+	}
+
+	targetPlatform := "iphonesimulator"
+	if target == "device" {
+		targetPlatform = "iphoneos"
+	}
+
+	return strings.Title(configuration) + "-" + targetPlatform
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -374,10 +374,12 @@ func main() {
 
 				log.Donef("The app.zip path is now available in the Environment Variable: %s (value: %s)", appZipPathEnvKey, zippedExportedPth)
 			}
+		} else {
+			log.Warnf("BP4 directory does not exist")
 		}
 	}
 
-	log.Warnf("BP4 Android checks that must be skipped")
+	log.Warnf("BP5 Android checks that must be skipped")
 
 	var apks, aabs []string
 	androidOutputDirExist := false
@@ -421,7 +423,7 @@ func main() {
 		}
 	}
 
-	log.Warnf("BP5 checking for existing directories")
+	log.Warnf("BP6 checking for existing directories")
 
 	if !iosOutputDirExist && !androidOutputDirExist {
 		log.Warnf("No ios nor android platform's output dir exist")

--- a/main.go
+++ b/main.go
@@ -374,9 +374,9 @@ func main() {
 
 				log.Donef("The app.zip path is now available in the Environment Variable: %s (value: %s)", appZipPathEnvKey, zippedExportedPth)
 			}
-		} else {
-			log.Warnf("BP4 directory does not exist")
 		}
+	} else {
+		log.Warnf("BP4 directory does not exist")
 	}
 
 	log.Warnf("BP5 Android checks that must be skipped")

--- a/main.go
+++ b/main.go
@@ -299,13 +299,17 @@ func main() {
 		fail("cordova build failed, error: %s", err)
 	}
 
+	log.Warnf("BP1 collecting outputs")
+
 	// collect outputs
 	var ipas, apps []string
 	iosOutputDirExist := false
 	iosOutputDir := filepath.Join(workDir, "platforms", "ios", "build", configs.Target)
 	if exist, err := pathutil.IsDirExists(iosOutputDir); err != nil {
 		fail("Failed to check if dir (%s) exist, error: %s", iosOutputDir, err)
+		log.Warnf("BP2 failing ios")
 	} else if exist {
+		log.Warnf("BP3 ios exists")
 		iosOutputDirExist = true
 
 		fmt.Println()
@@ -373,6 +377,8 @@ func main() {
 		}
 	}
 
+	log.Warnf("BP4 Android checks that must be skipped")
+
 	var apks, aabs []string
 	androidOutputDirExist := false
 	// examples for apk paths:
@@ -414,6 +420,8 @@ func main() {
 			}
 		}
 	}
+
+	log.Warnf("BP5 checking for existing directories")
 
 	if !iosOutputDirExist && !androidOutputDirExist {
 		log.Warnf("No ios nor android platform's output dir exist")

--- a/main.go
+++ b/main.go
@@ -178,9 +178,9 @@ func findIosTargetPathComponent(target string, configuration string, cordovaVers
 		if (target == "device") {
 			targetPlatform = "iphoneos"
 		}
-		return strings.Title(configuration) + "-" + targetPlatform
+		return fmt.Sprintf("%s-%s", strings.Title(configuration), targetPlatform)
 	} else {
-		return target
+		return target // "emulator" or "device"
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -311,21 +311,13 @@ func main() {
 		fail("cordova build failed, error: %s", err)
 	}
 
-	log.Warnf("BP1 collecting outputs")
-
 	// collect outputs
 	var ipas, apps []string
 	iosOutputDirExist := false
 	iosOutputDir := filepath.Join(workDir, "platforms", "ios", "build", findIosTargetPathComponent(configs.Target, configs.Configuration, configs.CordovaVersion))
-	log.Warnf("Output dir %s", iosOutputDir)
-	log.Warnf("Target %s", configs.Target)
-	log.Warnf("Configuration %s", configs.Configuration)
-	log.Warnf("Cordova versions %s", configs.CordovaVersion)
 	if exist, err := pathutil.IsDirExists(iosOutputDir); err != nil {
 		fail("Failed to check if dir (%s) exist, error: %s", iosOutputDir, err)
-		log.Warnf("BP2 failing ios")
 	} else if exist {
-		log.Warnf("BP3 ios exists")
 		iosOutputDirExist = true
 
 		fmt.Println()
@@ -391,11 +383,7 @@ func main() {
 				log.Donef("The app.zip path is now available in the Environment Variable: %s (value: %s)", appZipPathEnvKey, zippedExportedPth)
 			}
 		}
-	} else {
-		log.Warnf("BP4 directory does not exist")
 	}
-
-	log.Warnf("BP5 Android checks that must be skipped")
 
 	var apks, aabs []string
 	androidOutputDirExist := false
@@ -438,8 +426,6 @@ func main() {
 			}
 		}
 	}
-
-	log.Warnf("BP6 checking for existing directories")
 
 	if !iosOutputDirExist && !androidOutputDirExist {
 		log.Warnf("No ios nor android platform's output dir exist")

--- a/main.go
+++ b/main.go
@@ -305,6 +305,7 @@ func main() {
 	var ipas, apps []string
 	iosOutputDirExist := false
 	iosOutputDir := filepath.Join(workDir, "platforms", "ios", "build", configs.Target)
+	log.Warnf("Output dir %s", iosOutputDir)
 	if exist, err := pathutil.IsDirExists(iosOutputDir); err != nil {
 		fail("Failed to check if dir (%s) exist, error: %s", iosOutputDir, err)
 		log.Warnf("BP2 failing ios")

--- a/main.go
+++ b/main.go
@@ -172,6 +172,18 @@ func fail(format string, v ...interface{}) {
 	os.Exit(1)
 }
 
+func findIosTargetPathComponent(target string, configuration string, cordovaVersion string) string {
+	if cordovaVersion != "" && cordovaVersion[0:1] >= "7" {
+		targetPlatform := "iphonesimulator"
+		if (target == "device") {
+			targetPlatform = "iphoneos"
+		}
+		return strings.Title(configuration) + "-" + targetPlatform
+	} else {
+		return target
+	}
+}
+
 func main() {
 	var configs config
 	if err := stepconf.Parse(&configs); err != nil {
@@ -304,7 +316,7 @@ func main() {
 	// collect outputs
 	var ipas, apps []string
 	iosOutputDirExist := false
-	iosOutputDir := filepath.Join(workDir, "platforms", "ios", "build", configs.Target)
+	iosOutputDir := filepath.Join(workDir, "platforms", "ios", "build", findIosTargetPathComponent(configs.Target, configs.Configuration, configs.CordovaVersion))
 	log.Warnf("Output dir %s", iosOutputDir)
 	log.Warnf("Target %s", configs.Target)
 	log.Warnf("Configuration %s", configs.Configuration)

--- a/main.go
+++ b/main.go
@@ -306,6 +306,9 @@ func main() {
 	iosOutputDirExist := false
 	iosOutputDir := filepath.Join(workDir, "platforms", "ios", "build", configs.Target)
 	log.Warnf("Output dir %s", iosOutputDir)
+	log.Warnf("Target %s", configs.Target)
+	log.Warnf("Configuration %s", configs.Configuration)
+	log.Warnf("Cordova versions %s", configs.CordovaVersion)
 	if exist, err := pathutil.IsDirExists(iosOutputDir); err != nil {
 		fail("Failed to check if dir (%s) exist, error: %s", iosOutputDir, err)
 		log.Warnf("BP2 failing ios")

--- a/main_test.go
+++ b/main_test.go
@@ -157,3 +157,51 @@ func Test_checkBuildProducts(t *testing.T) {
 		})
 	}
 }
+
+func Test_findIosTargetPathComponentEmulatorOld(t *testing.T) {
+    got := findIosTargetPathComponent("emulator", "debug", "6.3.0")
+    want := "emulator"
+    if got != want {
+        t.Errorf("got %q, wanted %q", got, want)
+    }
+}
+
+func Test_findIosTargetPathComponentDeviceOld(t *testing.T) {
+    got := findIosTargetPathComponent("device", "debug", "6.3.0")
+    want := "device"
+    if got != want {
+        t.Errorf("got %q, wanted %q", got, want)
+    }
+}
+
+func Test_findIosTargetPathComponentEmulatorDebug7(t *testing.T) {
+    got := findIosTargetPathComponent("emulator", "debug", "7.0.0")
+    want := "Debug-iphonesimulator"
+    if got != want {
+        t.Errorf("got %q, wanted %q", got, want)
+    }
+}
+
+func Test_findIosTargetPathComponentEmulatorRelease7(t *testing.T) {
+    got := findIosTargetPathComponent("emulator", "release", "7.0.0")
+    want := "Release-iphonesimulator"
+    if got != want {
+        t.Errorf("got %q, wanted %q", got, want)
+    }
+}
+
+func Test_findIosTargetPathComponentDeviceRelease7(t *testing.T) {
+    got := findIosTargetPathComponent("device", "release", "7.0.0")
+    want := "Release-iphoneos"
+    if got != want {
+        t.Errorf("got %q, wanted %q", got, want)
+    }
+}
+
+func Test_findIosTargetPathComponentDeviceDebug7(t *testing.T) {
+    got := findIosTargetPathComponent("device", "debug", "7.0.0")
+    want := "Debug-iphoneos"
+    if got != want {
+        t.Errorf("got %q, wanted %q", got, want)
+    }
+}


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a PATCH [version update](https://semver.org/)

### Context

The Step is failing because of the deprecation of `CONFIGURATION_BUILD_DIR` in Cordova 7.0.0
https://cordova.apache.org/announcements/2023/07/10/cordova-ios-7.0.0.html

### Changes

Added a new method to find the iOS target path component of the build directory. It is backwards compatible with previous versions of Cordova.

### Investigation details

N/A

### Decisions

N/A
