### PR TITLE
Improve version parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -178,7 +178,7 @@ func findIosTargetPathComponent(target string, configuration string, cordovaVers
 		return target
 	}
 
-	majorVersion, err := strconv.Atoi(cordovaVersion[0:1])
+	majorVersion, err := strconv.Atoi(strings.Split(cordovaVersion, ".")[0])
 	if err != nil || majorVersion < 7 {
 		// Pre-Cordova-7 behavior: path segment is just "device" or "emulator"
 		return target

--- a/main_test.go
+++ b/main_test.go
@@ -198,8 +198,8 @@ func Test_findIosTargetPathComponentDeviceRelease7(t *testing.T) {
     }
 }
 
-func Test_findIosTargetPathComponentDeviceDebug7(t *testing.T) {
-    got := findIosTargetPathComponent("device", "debug", "7.0.0")
+func Test_findIosTargetPathComponentDeviceDebug10Plus(t *testing.T) {
+    got := findIosTargetPathComponent("device", "debug", "99.0.0")
     want := "Debug-iphoneos"
     if got != want {
         t.Errorf("got %q, wanted %q", got, want)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

As highlighted by https://github.com/bitrise-steplib/steps-cordova-archive/pull/56#issuecomment-1727317827, the version parsing function doesn't handle two-digit major versions

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
